### PR TITLE
Fix transform #1

### DIFF
--- a/lib/transform.js
+++ b/lib/transform.js
@@ -12,7 +12,7 @@ var through = require('through2');
 module.exports = function () {
   return through.obj(function (row, env, next) {
     /*jslint unparam: true*/
-    row.source = 'require("brout");' + row.source;
+    row = 'require("brout");' + row;
     this.push(row);
     next();
   });


### PR DESCRIPTION
I don’t know what exactly was wrong, whether browserify API has changed or whatever, but transform on browserify >6.3.3 works only that way. This fixes https://github.com/mantoni/brout.js/issues/1
