### PR TITLE
Fixes #4

### DIFF
--- a/lib/brout.js
+++ b/lib/brout.js
@@ -66,10 +66,10 @@ var originalWarn  = console.warn;
 var originalError = console.error;
 
 redirectLog('log', 'stdout');
+redirectLog('info', 'stdout');
 redirectLog('warn', 'stderr');
+redirectLog('error', 'stderr');
 
-console.info  = console.log;
-console.error = console.warn;
 
 console.trace = function () {
   try {


### PR DESCRIPTION
### Fixes #4: a referencing bug
  - fallback for stdout and stderr as console.info and console.warn respectively
  - this patch hooks  stdout and stderr to console.log and console.err respectively